### PR TITLE
added jvm arg element capability to flex unit ant task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ FlexUnit4UIListener/target/*
 *.iml
 */.settings
 /lib/
+out/

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/Compilation.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/Compilation.java
@@ -161,12 +161,18 @@ public class Compilation
       String frameworksPath = configuration.getFlexHome().getAbsolutePath() + File.separatorChar + FRAMEWORKS_RELATIVE_PATH;
       
       Java task = new Java();
+
       task.setFork(true);
       task.setFailonerror(true);
       task.setJar(new File(mxmlcPath));
       task.setProject(project);
       task.setDir(project.getBaseDir());
-      task.setMaxmemory("256M"); //MXMLC needs to eat
+
+      // MXMLC needs to eat - recommend using Xmx of 256 or greater
+      setVmArguments(task, configuration.getCommandLine().getArguments());
+
+      LoggingUtil.log("java command line: " + task.getCommandLine().toString());
+
       task.setErrorProperty("MXMLC_ERROR");
       
       Argument flexLibArgument = task.createArg();
@@ -200,8 +206,13 @@ public class Compilation
       
       return task;
    }
-   
-   
+
+   private void setVmArguments(final Java java, final String[] arguments) {
+      for (String argument : arguments) {
+         java.createJvmarg().setValue(argument);
+      }
+   }
+
    private void determineLoadConfigArgument(Java java)
    {
        if(configuration.getLoadConfig() != null)

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/FlexUnitTask.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/FlexUnitTask.java
@@ -20,6 +20,7 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.DynamicElement;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
+import org.apache.tools.ant.types.Commandline;
 import org.apache.tools.ant.types.FileSet;
 import org.flexunit.ant.tasks.configuration.TaskConfiguration;
 import org.flexunit.ant.tasks.types.LoadConfig;
@@ -172,7 +173,16 @@ public class FlexUnitTask extends Task implements DynamicElement
    {
       configuration.setWorkingDir(workingDirPath);
    }
-   
+
+   /**
+    * Adds a JVM argument.
+    *
+    * @return JVM argument created.
+    */
+   public Commandline.Argument createJvmarg() {
+      return configuration.createVmArgument();
+   }
+
    /**
     * Called by Ant to execute the task.
     */

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/CompilationConfiguration.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/CompilationConfiguration.java
@@ -19,6 +19,8 @@ package org.flexunit.ant.tasks.configuration;
 import java.io.File;
 
 import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.types.Commandline;
+import org.apache.tools.ant.types.CommandlineJava;
 import org.apache.tools.ant.types.FileSet;
 import org.flexunit.ant.LoggingUtil;
 import org.flexunit.ant.tasks.types.LibraryPaths;
@@ -27,6 +29,7 @@ import org.flexunit.ant.tasks.types.SourcePaths;
 
 public class CompilationConfiguration implements StepConfiguration
 {
+   private Commandline commandLine = new Commandline();
    private SourcePaths sources;
    private SourcePaths testSources;
    private LibraryPaths libraries;
@@ -156,5 +159,13 @@ public class CompilationConfiguration implements StepConfiguration
    {
        return loadConfig;
    }
-   
+
+    public Commandline.Argument createVmArgument() {
+        return getCommandLine().createArgument();
+    }
+
+    public Commandline getCommandLine() {
+        return commandLine;
+    }
+
 }

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/TaskConfiguration.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/TaskConfiguration.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
+import org.apache.tools.ant.types.Commandline;
 import org.apache.tools.ant.types.FileSet;
 import org.flexunit.ant.LoggingUtil;
 import org.flexunit.ant.tasks.types.LoadConfig;
@@ -124,7 +125,11 @@ public class TaskConfiguration
       fileset.setProject(project);
       compilationConfiguration.addLibrary(fileset);
    }
-   
+
+   public Commandline.Argument createVmArgument() {
+      return compilationConfiguration.createVmArgument();
+   }
+
    public void setHeadless(boolean headless)
    {
       testRunConfiguration.setHeadless(headless);

--- a/version.properties
+++ b/version.properties
@@ -16,4 +16,4 @@
 build.groupId=org.flexunit
 build.version=4.3.0
 build.number=20140410
-build.sdk=4.12.0
+build.sdk=4.15.0


### PR DESCRIPTION
I also updated the flex sdk to 4.15. My apologies if this causes any unintended issues.

On the other hand, it is possible to set the memory for the underlying Java task using jvm arg elements in the ant script.

Like so:

```
<flexunit ...>
   <jvmarg value="-Xmx${mxmlc.max.memory}" />
   ...
</flexunit>
```
